### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To use the extensions along your MATSim code, follow these two steps:
   ``` 
 
 <a id="swissRailRaptor" />
+
 ## SwissRailRaptor 
 
 The SwissRailRaptor is a fast public transport router. It is based on the RAPTOR algorithm
@@ -317,6 +318,7 @@ If you plan to use this method, make sure to set
 calling `SwissRailRaptorData.create(...)`.
 
 <a id="detPTSim" />
+
 ## Deterministic Public Transport Simulation 
 
 The deterministic pt simulation is a QSim engine, handling the movement of public transport vehicles

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ To use the extensions along your MATSim code, follow these two steps:
 	</dependency>
   ``` 
 
-## SwissRailRaptor <a id="swissRailRaptor" />
+<a id="swissRailRaptor" />
+## SwissRailRaptor 
 
 The SwissRailRaptor is a fast public transport router. It is based on the RAPTOR algorithm
 (Delling et al, 2012, Round-Based Public Transit Routing), and applies several optimizations,
@@ -315,7 +316,8 @@ If you plan to use this method, make sure to set
 `RaptorStaticConfig.setOptimization(RaptorOptimization.OneToAllRouting)` before
 calling `SwissRailRaptorData.create(...)`.
 
-## Deterministic Public Transport Simulation <a id="detPTSim" />
+<a id="detPTSim" />
+## Deterministic Public Transport Simulation 
 
 The deterministic pt simulation is a QSim engine, handling the movement of public transport vehicles
 in MATSim. The default `TransitQSimEngine` simulates all pt vehicles on the queue-based network. While

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use the extensions along your MATSim code, follow these two steps:
 	</dependency>
   ``` 
 
-## SwissRailRaptor <span id="swissRailRaptor" />
+## SwissRailRaptor <a id="swissRailRaptor" />
 
 The SwissRailRaptor is a fast public transport router. It is based on the RAPTOR algorithm
 (Delling et al, 2012, Round-Based Public Transit Routing), and applies several optimizations,
@@ -315,7 +315,7 @@ If you plan to use this method, make sure to set
 `RaptorStaticConfig.setOptimization(RaptorOptimization.OneToAllRouting)` before
 calling `SwissRailRaptorData.create(...)`.
 
-## Deterministic Public Transport Simulation <span id="detPTSim" />
+## Deterministic Public Transport Simulation <a id="detPTSim" />
 
 The deterministic pt simulation is a QSim engine, handling the movement of public transport vehicles
 in MATSim. The default `TransitQSimEngine` simulates all pt vehicles on the queue-based network. While


### PR DESCRIPTION
Simply fixed broken link tags in README.md. Right in the beggining, the two links to the sections within the readme file weren't working.