### PR TITLE
Improved transfer costs in SwissRailRaptor with min/max limits for costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,30 +280,38 @@ This can lead to problems, as empirical data shows that perceived costs for tran
 total travel time: A transfer during an urban commute of a total of 15 minutes is perceived 
 with a lower disutility than a transfer during a long-distance journey of 2 hours.
 
-SwissRailRaptor supports transfer costs based on the total travel of a route:
+SwissRailRaptor supports transfer costs based on the total travel of a route, with additional
+minimal and maximal boundaries for the transfer costs:
 
   ```$xml
    <module name="swissRailRaptor">
-     <param name="transferPenaltyTravelTimeToCostFactor" value="0.0003" />
+     <param name="transferPenaltyBaseCost" value="0.5" />
+     <param name="transferPenaltyCostPerTravelTimeHour" value="1.2" />
+     <param name="transferPenaltyMinCost" value="1.0" />
+     <param name="transferPenaltyMaxCost" value="5.0" />
    </module>
    ```
 
-If the `transferPenaltyTravelTimeToCostFactor` is configured differently from `0.0`,
+If the `transferPenaltyCostPerTravelTimeHour` is configured differently from `0.0`,
 transfer costs during route search are calculated as:
 
 ```
-singleTransferCost = fixedTransferCost + totalTravelTime * transferPenaltyTravelTimeToCostFactor;
+singleTransferCost = transferPenaltyBaseCost + (totalTravelTime/3600) * transferPenaltyCostPerTravelTimeHour;
+if (singleTransferCost < transferPenaltyMinCost) singleTransferCost = transferPenaltyMinCost;
+if (singleTransferCost > transferPenaltyMaxCost) singleTransferCost = transferPenaltyMaxCost;
 totalTransferCost = numberOfTransfers * singleTransferCost
 ```
 
-The fixed transfer cost is taken from the `planCalcScore`'s `utilityOfLineSwitch`, while the 
-`transferPenaltyTravelTimetoCostFactor` is taken from the SwissRailRaptor's configuration.
+If `transferPenaltyCostPerTravelTimeHour` is set to `0.0`, each transfer costs `-utilityOfLineSwitch`
+to stay backwards compatible with the default transit router. All other `transferPenalty`-parameters
+are ignored in this case. If the cost-per-traveltime-hour is set
+differently from `0.0`, `utilityOfLineSwitch` will be ignored and the aforementioned `transferPenaltyBaseCost`
+be used instead.
 
 Assuming a travel time disutility of 6 utils per hour, combined with opportunity costs of another
-6 utils per hour would result in a total travel time disutility of 0.00333 utils per second
-(`(6+6)/3600=0.00333`).
-The configured value of 0.0003 in the example above would thus correspond to a single transfer 
-having a (non-fixed) cost comparable to 9% of the total travel time.
+6 utils per hour would result in a total travel time disutility of 12 utils per hour.
+The configured value of 1.2 in the example above would thus correspond to a single transfer 
+having a (non-fixed) cost comparable to 10% of the total travel time.
 
 
 #### PT Least Cost Path Tree (one-to-all routing)

--- a/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
+++ b/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
@@ -27,14 +27,20 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
     private static final String PARAM_USE_INTERMODAL_ACCESS_EGRESS = "useIntermodalAccessEgress";
     private static final String PARAM_USE_MODE_MAPPING = "useModeMappingForPassengers";
     private static final String PARAM_SCORING_PARAMETERS = "scoringParameters";
-    private static final String PARAM_TRANSFER_PENALTY_FACTOR = "transferPenaltyTravelTimeToCostFactor";
+    private static final String PARAM_TRANSFER_PENALTY_BASE = "transferPenaltyBaseCost";
+    private static final String PARAM_TRANSFER_PENALTY_MIN = "transferPenaltyMinCost";
+    private static final String PARAM_TRANSFER_PENALTY_MAX = "transferPenaltyMaxCost";
+    private static final String PARAM_TRANSFER_PENALTY_PERHOUR = "transferPenaltyCostPerTravelTimeHour";
 
     private boolean useRangeQuery = false;
     private boolean useIntermodality = false;
     private boolean useModeMapping = false;
 
-    private double transferPenaltyTravelTimeToCostFactor = 0.0;
-    
+    private double transferPenaltyBaseCost = 0;
+    private double transferPenaltyMinCost = Double.NEGATIVE_INFINITY;
+    private double transferPenaltyMaxCost = Double.POSITIVE_INFINITY;
+    private double transferPenaltyHourlyCost = 0;
+
     private ScoringParameters scoringParameters = ScoringParameters.Default;
 
     private final Map<String, RangeQuerySettingsParameterSet> rangeQuerySettingsPerSubpop = new HashMap<>();
@@ -90,14 +96,44 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
         this.scoringParameters = scoringParameters;
     }
 
-    @StringGetter(PARAM_TRANSFER_PENALTY_FACTOR)
-    public double getTransferPenaltyTravelTimeToCostFactor() {
-        return transferPenaltyTravelTimeToCostFactor;
+    @StringGetter(PARAM_TRANSFER_PENALTY_BASE)
+    public double getTransferPenaltyBaseCost() {
+        return this.transferPenaltyBaseCost;
     }
 
-    @StringSetter(PARAM_TRANSFER_PENALTY_FACTOR)
-    public void setTransferPenaltyTravelTimeToCostFactor(double transferPenaltyTravelTimeToCostFactor) {
-        this.transferPenaltyTravelTimeToCostFactor = transferPenaltyTravelTimeToCostFactor;
+    @StringSetter(PARAM_TRANSFER_PENALTY_BASE)
+    public void setTransferPenaltyBaseCost(double baseCost) {
+        this.transferPenaltyBaseCost = baseCost;
+    }
+
+    @StringGetter(PARAM_TRANSFER_PENALTY_MIN)
+    public double getTransferPenaltyMinCost() {
+        return this.transferPenaltyMinCost;
+    }
+
+    @StringSetter(PARAM_TRANSFER_PENALTY_MIN)
+    public void setTransferPenaltyMinCost(double minCost) {
+        this.transferPenaltyMinCost = minCost;
+    }
+
+    @StringGetter(PARAM_TRANSFER_PENALTY_MAX)
+    public double getTransferPenaltyMaxCost() {
+        return this.transferPenaltyMaxCost;
+    }
+
+    @StringSetter(PARAM_TRANSFER_PENALTY_MAX)
+    public void setTransferPenaltyMaxCost(double maxCost) {
+        this.transferPenaltyMaxCost = maxCost;
+    }
+
+    @StringGetter(PARAM_TRANSFER_PENALTY_PERHOUR)
+    public double getTransferPenaltyCostPerTravelTimeHour() {
+        return this.transferPenaltyHourlyCost;
+    }
+
+    @StringSetter(PARAM_TRANSFER_PENALTY_PERHOUR)
+    public void setTransferPenaltyCostPerTravelTimeHour(double hourlyCost) {
+        this.transferPenaltyHourlyCost = hourlyCost;
     }
 
     @Override

--- a/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorParameters.java
+++ b/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorParameters.java
@@ -40,7 +40,9 @@ public class RaptorParameters {
     private double marginalUtilityOfWaitingPt_utl_s;
 
     private double transferPenaltyFixCostPerTransfer = 0.0;
-    private double transferPenaltyTravelTimeToCostFactor = 0.0;
+    private double transferPenaltyPerTravelTimeHour = 0.0;
+    private double transferPenaltyMinimum = Double.NEGATIVE_INFINITY;
+    private double transferPenaltyMaximum = Double.POSITIVE_INFINITY;
 
     private final SwissRailRaptorConfigGroup config;
 
@@ -104,12 +106,28 @@ public class RaptorParameters {
         this.transferPenaltyFixCostPerTransfer = transferPenaltyFixCostPerTransfer;
     }
 
-    public double getTransferPenaltyTravelTimeToCostFactor() {
-        return this.transferPenaltyTravelTimeToCostFactor;
+    public double getTransferPenaltyPerTravelTimeHour() {
+        return this.transferPenaltyPerTravelTimeHour;
     }
 
-    public void setTransferPenaltyTravelTimeToCostFactor(double transferPenaltyTravelTimeToCostFactor) {
-        this.transferPenaltyTravelTimeToCostFactor = transferPenaltyTravelTimeToCostFactor;
+    public void setTransferPenaltyPerTravelTimeHour(double transferPenaltyPerTravelTimeHour) {
+        this.transferPenaltyPerTravelTimeHour = transferPenaltyPerTravelTimeHour;
+    }
+
+    public double getTransferPenaltyMinimum() {
+        return this.transferPenaltyMinimum;
+    }
+
+    public void setTransferPenaltyMinimum(double transferPenaltyMinimum) {
+        this.transferPenaltyMinimum = transferPenaltyMinimum;
+    }
+
+    public double getTransferPenaltyMaximum() {
+        return this.transferPenaltyMaximum;
+    }
+
+    public void setTransferPenaltyMaximum(double transferPenaltyMaximum) {
+        this.transferPenaltyMaximum = transferPenaltyMaximum;
     }
 
 }

--- a/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
+++ b/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
@@ -89,8 +89,16 @@ public final class RaptorUtils {
 			}
 		}
 
-        raptorParams.setTransferPenaltyFixCostPerTransfer(-trConfig.getUtilityOfLineSwitch_utl());
-        raptorParams.setTransferPenaltyTravelTimeToCostFactor(advancedConfig.getTransferPenaltyTravelTimeToCostFactor());
+        double costPerHour = advancedConfig.getTransferPenaltyCostPerTravelTimeHour();
+        if (costPerHour == 0.0) {
+            // for backwards compatibility, use the default utility of line switch.
+            raptorParams.setTransferPenaltyFixCostPerTransfer(-trConfig.getUtilityOfLineSwitch_utl());
+        } else {
+            raptorParams.setTransferPenaltyFixCostPerTransfer(advancedConfig.getTransferPenaltyBaseCost());
+        }
+        raptorParams.setTransferPenaltyPerTravelTimeHour(costPerHour);
+        raptorParams.setTransferPenaltyMinimum(advancedConfig.getTransferPenaltyMinCost());
+        raptorParams.setTransferPenaltyMaximum(advancedConfig.getTransferPenaltyMaxCost());
 
         return raptorParams;
     }

--- a/src/test/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroupTest.java
+++ b/src/test/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroupTest.java
@@ -40,7 +40,7 @@ public class SwissRailRaptorConfigGroupTest {
             config1.setUseRangeQuery(true);
             config1.setUseIntermodalAccessEgress(true);
             config1.setUseModeMappingForPassengers(true);
-            config1.setTransferPenaltyTravelTimeToCostFactor(0.0031);
+            config1.setTransferPenaltyCostPerTravelTimeHour(0.0031 * 3600);
         }
 
         SwissRailRaptorConfigGroup config2 = writeRead(config1);
@@ -49,7 +49,7 @@ public class SwissRailRaptorConfigGroupTest {
         Assert.assertTrue(config2.isUseRangeQuery());
         Assert.assertTrue(config2.isUseIntermodalAccessEgress());
         Assert.assertTrue(config2.isUseModeMappingForPassengers());
-        Assert.assertEquals(0.0031, config2.getTransferPenaltyTravelTimeToCostFactor(), 0.0);
+        Assert.assertEquals(0.0031 * 3600, config2.getTransferPenaltyCostPerTravelTimeHour(), 0.0);
     }
 
     @Test

--- a/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
+++ b/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
@@ -748,8 +748,8 @@ public class SwissRailRaptorTest {
             Assert.assertEquals(expectedCost, route1.getTotalCosts(), 1e-7);
         }
 
-        { // test 2 + 0.0025 * tt
-            Config config = prepareConfig(2, 0.0025);
+        { // test 2 + 9 * tt[h]
+            Config config = prepareConfig(2, 9);
             SwissRailRaptor raptor = createTransitRouter(f.schedule, config, f.network);
 
             Coord fromCoord = new Coord(0, 100);
@@ -768,8 +768,8 @@ public class SwissRailRaptorTest {
             Assert.assertEquals(expectedCost, route1.getTotalCosts(), 1e-7);
         }
 
-        { // test 2 + 0.0025 * tt, longer trip
-            Config config = prepareConfig(2, 0.0025);
+        { // test 2 + 9 * tt[h], longer trip
+            Config config = prepareConfig(2, 9);
             SwissRailRaptor raptor = createTransitRouter(f.schedule, config, f.network);
 
             Coord fromCoord = new Coord(0, 100);
@@ -800,7 +800,8 @@ public class SwissRailRaptorTest {
         config.plansCalcRoute().addParameterSet(walkParameters);
 
         config.planCalcScore().setUtilityOfLineSwitch(-transferFixedCost);
-        srrConfig.setTransferPenaltyTravelTimeToCostFactor(transferRelativeCostFactor);
+        srrConfig.setTransferPenaltyBaseCost(transferFixedCost);
+        srrConfig.setTransferPenaltyCostPerTravelTimeHour(transferRelativeCostFactor);
 
         return config;
     }

--- a/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTreeTest.java
+++ b/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTreeTest.java
@@ -234,8 +234,8 @@ public class SwissRailRaptorTreeTest {
 
         Assert.assertEquals("wrong number of reached stops.", f.schedule.getFacilities().size(), map.size());
 
-        assertTravelInfo(map, 0 ,  "2", 1, "07:33:00", "07:54:06"); // transfer at B, walk at A
-        assertTravelInfo(map, 1 ,  "2", 1, "07:33:00", "07:54:00"); // transfer at B
+        assertTravelInfo(map, 0 ,  "2", 0, "07:49:00", "07:54:06"); // initial transfer at B (not counted), walk at A
+        assertTravelInfo(map, 1 ,  "2", 0, "07:49:00", "07:54:00"); // initial transfer at B (not counted)
         assertTravelInfo(map, 2 ,  "2", 0, "07:30:00", "07:30:00"); // from B, we started here
         assertTravelInfo(map, 3 ,  "2", 0, "07:30:06", "07:30:06"); // from B, walk
         assertTravelInfo(map, 4 ,  "2", 0, "07:33:00", "07:38:00"); // from B, directly reachable


### PR DESCRIPTION
Changed config-parameter `transferPenaltyTravelTimetoCostFactor` with unit [cost/second] to `transferPenaltyCostPerTravelTimeHour` with unit [cost/hour] to stay consistent with scoring parameters which are typically also [utils/hour].