### PR TITLE
Feature/weighted pt skims

### DIFF
--- a/src/main/java/ch/sbb/matsim/analysis/skims/CalculateSkimMatrices.java
+++ b/src/main/java/ch/sbb/matsim/analysis/skims/CalculateSkimMatrices.java
@@ -72,6 +72,7 @@ public class CalculateSkimMatrices {
 
     public static final String CAR_TRAVELTIMES_FILENAME = "car_traveltimes.csv.gz";
     public static final String CAR_DISTANCES_FILENAME = "car_distances.csv.gz";
+    public static final String PT_DISTANCES_FILENAME = "pt_distances.csv.gz";
     public static final String PT_TRAVELTIMES_FILENAME = "pt_traveltimes.csv.gz";
     public static final String PT_ACCESSTIMES_FILENAME = "pt_accesstimes.csv.gz";
     public static final String PT_EGRESSTIMES_FILENAME = "pt_egresstimes.csv.gz";
@@ -357,6 +358,7 @@ public class CalculateSkimMatrices {
         log.info("write PT matrices to " + outputDirectory);
         FloatMatrixIO.writeAsCSV(matrices.adaptionTimeMatrix, outputDirectory + "/" + PT_ADAPTIONTIMES_FILENAME);
         FloatMatrixIO.writeAsCSV(matrices.frequencyMatrix, outputDirectory + "/" + PT_FREQUENCIES_FILENAME);
+        FloatMatrixIO.writeAsCSV(matrices.distanceMatrix, outputDirectory + "/" + PT_DISTANCES_FILENAME);
         FloatMatrixIO.writeAsCSV(matrices.travelTimeMatrix, outputDirectory + "/" + PT_TRAVELTIMES_FILENAME);
         FloatMatrixIO.writeAsCSV(matrices.accessTimeMatrix, outputDirectory + "/" + PT_ACCESSTIMES_FILENAME);
         FloatMatrixIO.writeAsCSV(matrices.egressTimeMatrix, outputDirectory + "/" + PT_EGRESSTIMES_FILENAME);

--- a/src/main/java/ch/sbb/matsim/analysis/skims/MatricesToXY.java
+++ b/src/main/java/ch/sbb/matsim/analysis/skims/MatricesToXY.java
@@ -82,6 +82,10 @@ public class MatricesToXY {
         FloatMatrix<String> ptFrequencies = new FloatMatrix<>(zonesById.keySet(), Float.NaN);
         FloatMatrixIO.readAsCSV(ptFrequencies, new File(matricesDirectory, CalculateSkimMatrices.PT_FREQUENCIES_FILENAME).getAbsolutePath(), id -> id);
 
+        log.info("loading pt distances");
+        FloatMatrix<String> ptDistances = new FloatMatrix<>(zonesById.keySet(), Float.NaN);
+        FloatMatrixIO.readAsCSV(ptDistances, new File(matricesDirectory, CalculateSkimMatrices.PT_DISTANCES_FILENAME).getAbsolutePath(), id -> id);
+
         log.info("loading pt travel times");
         FloatMatrix<String> ptTravelTimes = new FloatMatrix<>(zonesById.keySet(), Float.NaN);
         FloatMatrixIO.readAsCSV(ptTravelTimes, new File(matricesDirectory, CalculateSkimMatrices.PT_TRAVELTIMES_FILENAME).getAbsolutePath(), id -> id);
@@ -112,7 +116,7 @@ public class MatricesToXY {
 
         log.info("Start writing xy csv to " + xyCsvOutputFilename);
         try (BufferedWriter writer = IOUtils.getBufferedWriter(xyCsvOutputFilename)) {
-            writer.write("FROM,FROM_X,FROM_Y,TO,TO_X,TO_Y,CAR_TRAVELTIME,CAR_DISTANCE,PT_ADAPTIONTIME,PT_FREQUENCY,PT_TRAVELTIME,PT_ACCESSTIME,PT_EGRESSTIME,PT_TRANSFERCOUNT,PT_TRAINSHARE_DIST,PT_TRAINSHARE_TIME,BEELINE_DISTANCE\n");
+            writer.write("FROM,FROM_X,FROM_Y,TO,TO_X,TO_Y,CAR_TRAVELTIME,CAR_DISTANCE,PT_ADAPTIONTIME,PT_FREQUENCY,PT_DISTANCE,PT_TRAVELTIME,PT_ACCESSTIME,PT_EGRESSTIME,PT_TRANSFERCOUNT,PT_TRAINSHARE_DIST,PT_TRAINSHARE_TIME,BEELINE_DISTANCE\n");
 
             for (Map.Entry<String, Point> fromE : coords.entrySet()) {
                 String fromId = fromE.getKey();
@@ -125,6 +129,7 @@ public class MatricesToXY {
                     float carDistance = carDistances.get(fromId, toId);
                     float ptAdaptionTime = ptAdaptionTimes.get(fromId, toId);
                     float ptFrequency = ptFrequencies.get(fromId, toId);
+                    float ptDistance = ptDistances.get(fromId, toId);
                     float ptTravelTime = ptTravelTimes.get(fromId, toId);
                     float ptAccessTime = ptAccessTimes.get(fromId, toId);
                     float ptEgressTime = ptEgressTimes.get(fromId, toId);
@@ -143,6 +148,7 @@ public class MatricesToXY {
                     writer.write(Float.toString(carDistance)); writer.append(',');
                     writer.write(Float.toString(ptAdaptionTime)); writer.append(',');
                     writer.write(Float.toString(ptFrequency)); writer.append(',');
+                    writer.write(Float.toString(ptDistance)); writer.append(',');
                     writer.write(Float.toString(ptTravelTime)); writer.append(',');
                     writer.write(Float.toString(ptAccessTime)); writer.append(',');
                     writer.write(Float.toString(ptEgressTime)); writer.append(',');

--- a/src/main/java/ch/sbb/matsim/analysis/skims/PTSkimMatrices.java
+++ b/src/main/java/ch/sbb/matsim/analysis/skims/PTSkimMatrices.java
@@ -267,6 +267,7 @@ public class PTSkimMatrices {
             this.pti.egressTimeMatrix.add(fromZoneId, toZoneId, egressTime);
             this.pti.transferCountMatrix.add(fromZoneId, toZoneId, transferCount);
             this.pti.travelTimeMatrix.add(fromZoneId, toZoneId, travelTime);
+            this.pti.distanceMatrix.add(fromZoneId, toZoneId, (float) totalDistance);
             this.pti.trainDistanceShareMatrix.add(fromZoneId, toZoneId, trainShareByDistance);
             this.pti.trainTravelTimeShareMatrix.add(fromZoneId, toZoneId, trainShareByTravelTime);
 
@@ -467,6 +468,7 @@ public class PTSkimMatrices {
         private void invalidateEntries(T fromZone, T toZone) {
             this.pti.adaptionTimeMatrix.set(fromZone, toZone, Float.POSITIVE_INFINITY);
             this.pti.frequencyMatrix.set(fromZone, toZone, Float.POSITIVE_INFINITY);
+            this.pti.distanceMatrix.set(fromZone, toZone, Float.POSITIVE_INFINITY);
             this.pti.travelTimeMatrix.set(fromZone, toZone, Float.POSITIVE_INFINITY);
             this.pti.accessTimeMatrix.set(fromZone, toZone, Float.POSITIVE_INFINITY);
             this.pti.egressTimeMatrix.set(fromZone, toZone, Float.POSITIVE_INFINITY);
@@ -503,6 +505,7 @@ public class PTSkimMatrices {
         public final FloatMatrix<T> adaptionTimeMatrix;
         public final FloatMatrix<T> frequencyMatrix;
 
+        public final FloatMatrix<T> distanceMatrix;
         public final FloatMatrix<T> travelTimeMatrix;
         public final FloatMatrix<T> accessTimeMatrix;
         public final FloatMatrix<T> egressTimeMatrix;
@@ -516,6 +519,7 @@ public class PTSkimMatrices {
             this.adaptionTimeMatrix = new FloatMatrix<>(zones, 0);
             this.frequencyMatrix = new FloatMatrix<>(zones, 0);
 
+            this.distanceMatrix = new FloatMatrix<>(zones, 0);
             this.travelTimeMatrix = new FloatMatrix<>(zones, 0);
             this.accessTimeMatrix = new FloatMatrix<>(zones, 0);
             this.egressTimeMatrix = new FloatMatrix<>(zones, 0);

--- a/src/test/java/ch/sbb/matsim/analysis/skims/PTSkimMatricesTest.java
+++ b/src/test/java/ch/sbb/matsim/analysis/skims/PTSkimMatricesTest.java
@@ -50,7 +50,6 @@ public class PTSkimMatricesTest {
     public void testCalcAvgAdaptionTime() {
         List<ODConnection> connections = new ArrayList<>();
 
-        // we'll misuse the transferCount as a connection identifier
         // 15-min headway
         connections.add(new ODConnection(Time.parseTime("08:05:00"), 600, 60, 150, 0, null));
         connections.add(new ODConnection(Time.parseTime("08:20:00"), 600, 60, 150, 0, null));
@@ -75,8 +74,8 @@ public class PTSkimMatricesTest {
         // resulting in a slightly higher adaption time
 
         adaptionTime = PTSkimMatrices.RowWorker.calcAverageAdaptionTime(connections, Time.parseTime("08:00:00"), Time.parseTime("09:00:00"));
-        Assert.assertEquals(228, adaptionTime, 1e-7);
-        // the frequency would be 3600 / 228 / 4 = 3.94736
+        Assert.assertEquals(254, adaptionTime, 1e-7);
+        // the frequency would be 3600 / 254 / 4 = 3.5433
 
         connections.add(new ODConnection(Time.parseTime("08:15:00"), 300, 60, 150, 0, null));
 
@@ -84,7 +83,7 @@ public class PTSkimMatricesTest {
         Assert.assertEquals(6, connections.size());
 
         adaptionTime = PTSkimMatrices.RowWorker.calcAverageAdaptionTime(connections, Time.parseTime("08:00:00"), Time.parseTime("09:00:00"));
-        Assert.assertEquals(193, adaptionTime, 1e-7);
-        // the frequency would be 3600 / 193 / 4 = 4.66321
+        Assert.assertEquals(216, adaptionTime, 1e-7);
+        // the frequency would be 3600 / 216 / 4 = 4.1666
     }
 }


### PR DESCRIPTION
until now, only the pt service frequency and pt adaption time used an average over multiple connections, pt travel time, transfer counts etc all just used the value of the best connection. with these changes, these other pt skim matrices now also use averages over multiple connections, weighted by the timespan their "roof" from the adaption time calculation covers.