### PR TITLE
Fix some issues with pt skim matrices.

### DIFF
--- a/src/main/java/ch/sbb/matsim/analysis/skims/PTSkimMatrices.java
+++ b/src/main/java/ch/sbb/matsim/analysis/skims/PTSkimMatrices.java
@@ -284,7 +284,7 @@ public class PTSkimMatrices {
                     Id<TransitStopFacility> egressStopId = egressEntry.getKey();
                     Double egressTime = egressEntry.getValue();
                     TravelInfo info = tree.get(egressStopId);
-                    if (info != null) {
+                    if (info != null && !info.isWalkOnly()) {
                         ODConnection connection = new ODConnection(info.ptDepartureTime, info.ptTravelTime, info.accessTime, egressTime, info.transferCount, info);
                         connections.add(connection);
                     }
@@ -365,7 +365,7 @@ public class PTSkimMatrices {
             for (double time = minDepartureTime; time < maxDepartureTime; time += 60.0) {
                 double adaptionTime;
 
-                if (time >= nextDepartureTime) {
+                while (time >= nextDepartureTime) {
                     prevDepartureTime = nextDepartureTime;
                     prevConnection = nextConnection;
                     if (connectionIterator.hasNext()) {

--- a/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -921,5 +921,19 @@ public class SwissRailRaptorCore {
             Facility toFacility = this.destinationPath.toRouteStop.routeStop.getStopFacility();
             return createRaptorRoute(fromFacility, toFacility, this.destinationPath, firstPath.arrivalTime);
         }
+
+        public boolean isWalkOnly() {
+            if (this.destinationPath.comingFrom == null) {
+                return true;
+            }
+            PathElement pe = this.destinationPath.comingFrom;
+            while (pe != null) {
+                if (!pe.isTransfer) {
+                    return false;
+                }
+                pe = pe.comingFrom;
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
1. In very small, neighboured zones, the best "pt connection" as returned by the pt-router was to walk. In this case, a "pt walk" was found for every query time, resulting in an adaption time of 30 seconds for connections between such zones. Now, pure walk-connections will be ignored, potentially leading to "Infinity" values for the adaption time between such zones, when no real pt connection is found because walk is always considered faster.
2. In rare cases, more than two useful connections leaving within the same minute could have been found, leading to negative adaption times as this special case was not correctly handled.

MEMOP-959.