### PR TITLE
The detection of walk-only trips ignored the last segment of a trip.

### DIFF
--- a/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -926,7 +926,7 @@ public class SwissRailRaptorCore {
             if (this.destinationPath.comingFrom == null) {
                 return true;
             }
-            PathElement pe = this.destinationPath.comingFrom;
+            PathElement pe = this.destinationPath;
             while (pe != null) {
                 if (!pe.isTransfer) {
                     return false;


### PR DESCRIPTION
So if the trip consisted of only a single pt leg, this pt leg got ignored and the trip mistakenly identified as walk-only.